### PR TITLE
Typography components for easier pure HTML development

### DIFF
--- a/src/lib/components/ui/.eslintrc
+++ b/src/lib/components/ui/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^\\$\\$(Props|Events|Slots|Generic)$"
+      }
+    ]
+  }
+}

--- a/src/lib/components/ui/typography/h1.svelte
+++ b/src/lib/components/ui/typography/h1.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { cn } from '$lib/utils.js';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  type $$Props = HTMLAttributes<HTMLHeadingElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<h1 {...$$restProps}
+    class={cn('scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl', className)}>
+	<slot />
+</h1>

--- a/src/lib/components/ui/typography/h2.svelte
+++ b/src/lib/components/ui/typography/h2.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLHeadingElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+<!-- border-b pb-2 -->
+<h2 {...$$restProps}
+    class={cn('scroll-m-20 text-3xl font-semibold tracking-tight first:mt-0', className)}>
+	<slot />
+</h2>

--- a/src/lib/components/ui/typography/h3.svelte
+++ b/src/lib/components/ui/typography/h3.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLHeadingElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<h3 {...$$restProps}
+    class={cn('scroll-m-20 text-2xl font-semibold tracking-tight', className)}>
+	<slot />
+</h3>

--- a/src/lib/components/ui/typography/h4.svelte
+++ b/src/lib/components/ui/typography/h4.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLHeadingElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<h4 {...$$restProps}
+    class={cn('scroll-m-20 text-xl font-semibold tracking-tight', className)}>
+	<slot />
+</h4>

--- a/src/lib/components/ui/typography/index.ts
+++ b/src/lib/components/ui/typography/index.ts
@@ -1,0 +1,29 @@
+import H1 from './h1.svelte';
+import H2 from './h2.svelte';
+import H3 from './h3.svelte';
+import H4 from './h4.svelte';
+import Lead from './lead.svelte';
+import P from './p.svelte';
+import Large from './large.svelte';
+import Small from './small.svelte';
+import Muted from './muted.svelte';
+import InlineCode from './inline-code.svelte';
+import List from './list.svelte';
+import Quote from './quote.svelte';
+
+// inspired by https://github.com/kian1991/shadcn-typography
+
+export {
+	H1,
+  H2,
+  H3,
+  H4,
+  Lead,
+  P,
+  Large,
+  Small,
+  Muted,
+  InlineCode,
+  List,
+  Quote,
+};

--- a/src/lib/components/ui/typography/inline-code.svelte
+++ b/src/lib/components/ui/typography/inline-code.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLSpanElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<code {...$$restProps}
+    class={cn('relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold', className)}>
+	<slot />
+</code>

--- a/src/lib/components/ui/typography/large.svelte
+++ b/src/lib/components/ui/typography/large.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLDivElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<div {...$$restProps}
+    class={cn('text-lg font-semibold', className)}>
+	<slot />
+</div>

--- a/src/lib/components/ui/typography/lead.svelte
+++ b/src/lib/components/ui/typography/lead.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLParagraphElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<p {...$$restProps}
+    class={cn('text-xl text-muted-foreground', className)}>
+	<slot />
+</p>

--- a/src/lib/components/ui/typography/list.svelte
+++ b/src/lib/components/ui/typography/list.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLUListElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<ul {...$$restProps}
+    class={cn('my-6 ml-6 list-disc [&>li]:mt-2', className)}>
+	<slot />
+</ul>

--- a/src/lib/components/ui/typography/muted.svelte
+++ b/src/lib/components/ui/typography/muted.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLSpanElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<span {...$$restProps}
+    class={cn('text-sm text-muted-foreground', className)}>
+	<slot />
+</span>

--- a/src/lib/components/ui/typography/p.svelte
+++ b/src/lib/components/ui/typography/p.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLParagraphElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<p {...$$restProps}
+    class={cn('leading-7 [&:not(:first-child)]:mt-6', className)}>
+	<slot />
+</p>

--- a/src/lib/components/ui/typography/quote.svelte
+++ b/src/lib/components/ui/typography/quote.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLQuoteElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<blockquote {...$$restProps}
+    class={cn('mt-6 border-l-2 pl-6 italic text-muted-foreground', className)}>
+	<slot />
+</blockquote>

--- a/src/lib/components/ui/typography/small.svelte
+++ b/src/lib/components/ui/typography/small.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	type $$Props = HTMLAttributes<HTMLParagraphElement>;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<p {...$$restProps}
+    class={cn('text-sm font-medium leading-none', className)}>
+	<slot />
+</p>


### PR DESCRIPTION
I created these components to have a more consistent interface and to make pure HTML development easier.
There is also a .eslintrc to prevent linting when for example components define $$Props to specify the type for $$restProps as $$Props is not directly used in the rest of the component.